### PR TITLE
Remove release notes

### DIFF
--- a/releasenotes/notes/admin-domain-7eecf32a4f043f66.yaml
+++ b/releasenotes/notes/admin-domain-7eecf32a4f043f66.yaml
@@ -1,5 +1,0 @@
----
-features:
-  - |
-    With `--admin-domain` it is now possible to specifcy the user domain for the
-    admin account.

--- a/releasenotes/notes/assign-admin-user-on-already-created-projects-5c58c4287a1e20e0.yaml
+++ b/releasenotes/notes/assign-admin-user-on-already-created-projects-5c58c4287a1e20e0.yaml
@@ -1,5 +1,0 @@
----
-features:
-  - |
-    It's now possible to assign the admin user of a domain to an
-    already created project.

--- a/releasenotes/notes/assign-domain-manager-role-ee0eb7aa98e28aec.yaml
+++ b/releasenotes/notes/assign-domain-manager-role-ee0eb7aa98e28aec.yaml
@@ -1,5 +1,0 @@
----
-features:
-  - |
-    When a new domain is created, the domain manager role is now
-    assigned to the associated admin user.

--- a/releasenotes/notes/create-domain-only-29c45920b8e18a7e.yaml
+++ b/releasenotes/notes/create-domain-only-29c45920b8e18a7e.yaml
@@ -1,5 +1,0 @@
----
-features:
-  - |
-    With the `--create-domain` argument it's possible to create a new
-    domain without creating a new project.

--- a/releasenotes/notes/manage-ldap-a5e1015eb2b5ea78.yaml
+++ b/releasenotes/notes/manage-ldap-a5e1015eb2b5ea78.yaml
@@ -1,5 +1,0 @@
----
-features:
-  - |
-    With the script manage-ldap it is possible to add all users in a certain
-    LDAP group to all projects of a certain domain.

--- a/releasenotes/notes/public-network-d0da1ce1481bf807.yaml
+++ b/releasenotes/notes/public-network-d0da1ce1481bf807.yaml
@@ -1,5 +1,0 @@
----
-features:
-  - |
-    With the `public_network` parameter it is now possible to enable a public
-    network on a project with the help of a quota class.

--- a/releasenotes/notes/use-default-quota-class-73e28b2c6f12fa63.yaml
+++ b/releasenotes/notes/use-default-quota-class-73e28b2c6f12fa63.yaml
@@ -1,4 +1,0 @@
----
-features:
-  - |
-    Use a default for `quotaclass` if none has been set.

--- a/releasenotes/notes/volume-types-87c81e8d37c27346.yaml
+++ b/releasenotes/notes/volume-types-87c81e8d37c27346.yaml
@@ -1,5 +1,0 @@
----
-features:
-  - |
-    It's now possible to add private volume types to a quota class.
-    Private volume types will then be available in those projects.


### PR DESCRIPTION
We manage the release notes again in the central osism/release and osism/osism.github.io repository.