### PR TITLE
Pin click

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 PyYAML==6.0.2
+click==8.1.8
 deepmerge==2.0
 dynaconf==3.2.11
 loguru==0.7.3


### PR DESCRIPTION
typer is broken with click 8.2.0, pin to the previous, working version for now.