### PR TITLE
Fix black 26.3.1 formatting

### DIFF
--- a/openstack_project_manager/create.py
+++ b/openstack_project_manager/create.py
@@ -12,7 +12,6 @@ import openstack
 from tabulate import tabulate
 from typing import Optional
 
-
 # Default roles to be assigned to a new user for a project
 DEFAULT_ROLES = ["member", "load-balancer_member"]
 DEFAULT_MANAGER_ROLE = "manager"

--- a/openstack_project_manager/create_user.py
+++ b/openstack_project_manager/create_user.py
@@ -9,7 +9,6 @@ import openstack
 from tabulate import tabulate
 from typing import Optional
 
-
 # Default roles to be assigned to a new user for a project
 DEFAULT_ROLES = ["member", "load-balancer_member"]
 

--- a/test/unit/test_create.py
+++ b/test/unit/test_create.py
@@ -8,7 +8,6 @@ from typer.testing import CliRunner
 
 from openstack_project_manager.create import generate_password, run
 
-
 app = typer.Typer()
 app.command()(run)
 

--- a/test/unit/test_create_ldap.py
+++ b/test/unit/test_create_ldap.py
@@ -7,7 +7,6 @@ from typing import Any
 
 from openstack_project_manager.create_ldap import run
 
-
 app = typer.Typer()
 app.command()(run)
 

--- a/test/unit/test_create_user.py
+++ b/test/unit/test_create_user.py
@@ -8,7 +8,6 @@ from typer.testing import CliRunner
 
 from openstack_project_manager.create_user import generate_password, run
 
-
 app = typer.Typer()
 app.command()(run)
 

--- a/test/unit/test_manage.py
+++ b/test/unit/test_manage.py
@@ -41,12 +41,10 @@ from openstack_project_manager.manage import (
     run,
 )
 
-
 app = typer.Typer()
 app.command()(run)
 
-MOCK_QUOTA_CLASSES = yaml.safe_load(
-    """
+MOCK_QUOTA_CLASSES = yaml.safe_load("""
 ---
 default:
   compute:
@@ -79,8 +77,7 @@ flavor_test:
   parent: default
   flavors:
     - flavor_name
-"""
-)
+""")
 
 
 class CloudTest(unittest.TestCase):

--- a/test/unit/test_manage_ldap.py
+++ b/test/unit/test_manage_ldap.py
@@ -7,7 +7,6 @@ from typing import Any
 
 from openstack_project_manager.manage_ldap import run
 
-
 app = typer.Typer()
 app.command()(run)
 


### PR DESCRIPTION
## Summary
- Reformat code to comply with black 26.3.1 stable style (updated in osism/zuul-jobs#180)

## Test plan
- [ ] python-black Zuul job passes