### PR TITLE
Allow specification of multiple classes.yml files

### DIFF
--- a/openstack_project_manager/manage.py
+++ b/openstack_project_manager/manage.py
@@ -13,6 +13,7 @@ import yaml
 import typer
 from typing import List, Optional, Tuple
 from typing_extensions import Annotated
+from pathlib import Path
 
 DEFAULT_ROLES = ["member", "load-balancer_member"]
 
@@ -96,9 +97,17 @@ class Configuration:
         self.CACHE_ADMIN_USERS: dict = {}
 
 
-def get_quotaclass(classes: str, quotaclass: str) -> Optional[dict]:
-    with open(classes, "r") as fp:
-        quotaclasses = yaml.load(fp, Loader=yaml.SafeLoader)
+def get_quotaclass(classes: list[Path], quotaclass: str) -> Optional[dict]:
+    quotaclasses_raw = "---"
+    for classes_path in classes:
+        if classes_path.exists() and classes_path.is_file():
+            # NOTE: Concantenate classes, removing potential leading document separator
+            quotaclasses_raw += "\n" + classes_path.read_text().lstrip().removeprefix(
+                "---\n"
+            )
+
+    # NOTE: YAML load concatenated classes, so that later definitions overwrite earlier ones, while allowing usage of anchors referencing keys in other files
+    quotaclasses = yaml.load(quotaclasses_raw, Loader=yaml.SafeLoader)
 
     if quotaclass not in quotaclasses:
         return None
@@ -130,7 +139,7 @@ def check_bool(project: openstack.identity.v3.project.Project, param: str) -> bo
 def check_quota(
     configuration: Configuration,
     project: openstack.identity.v3.project.Project,
-    classes: str,
+    classes: list[Path],
 ) -> None:
 
     quotaclass_name = ""
@@ -395,7 +404,7 @@ def manage_external_network_rbacs(
     configuration: Configuration,
     project: openstack.identity.v3.project.Project,
     domain: openstack.identity.v3.domain.Domain,
-    classes: str,
+    classes: list[Path],
 ) -> None:
 
     if "quotaclass" in project:
@@ -456,7 +465,7 @@ def check_volume_types(
     configuration: Configuration,
     project: openstack.identity.v3.project.Project,
     domain: openstack.identity.v3.domain.Domain,
-    classes: str,
+    classes: list[Path],
 ) -> None:
 
     if "quotaclass" in project:
@@ -541,7 +550,7 @@ def manage_default_volume_type(
     configuration: Configuration,
     project: openstack.identity.v3.project.Project,
     domain: openstack.identity.v3.domain.Domain,
-    classes: str,
+    classes: list[Path],
 ) -> None:
     logger.info(f"{project.name} - managing default volume type")
     if "quotaclass" in project:
@@ -619,7 +628,7 @@ def check_flavors(
     configuration: Configuration,
     project: openstack.identity.v3.project.Project,
     domain: openstack.identity.v3.domain.Domain,
-    classes: str,
+    classes: list[Path],
 ) -> None:
 
     if "quotaclass" in project:
@@ -1305,7 +1314,7 @@ def cache_images(
 def process_project(
     configuration: Configuration,
     project: openstack.identity.v3.project.Project,
-    classes: str,
+    classes: list[Path],
     manage_endpoints: bool,
     manage_homeprojects: bool,
     manage_privatevolumetypes: bool,
@@ -1373,7 +1382,7 @@ def process_project(
 def handle_unmanaged_project(
     configuration: Configuration,
     project: openstack.identity.v3.project.Project,
-    classes: str,
+    classes: list[Path],
 ) -> None:
     # the service project must always be able to access the public network.
     if project.name == "service":
@@ -1438,8 +1447,18 @@ def run(
         str, typer.Option("--admin-domain", help="Admin domain")
     ] = "default",
     classes: Annotated[
-        str, typer.Option("--classes", help="Path to the classes.yml file")
-    ] = "etc/classes.yml",
+        list[Path],
+        typer.Option(
+            "--classes",
+            help=(
+                "Path to a classes.yml file. May be specified multiple times, in which case YAML files will be merged with the latter ones taking precedence "
+                "over previous ones. Non-existent files will be skipped"
+            ),
+        ),
+    ] = [
+        Path("etc/classes.yml"),
+        Path("/opt/configuration/environments/openstack/project-manager/classes.yml"),
+    ],
     endpoints: Annotated[
         str, typer.Option("--endpoints", help="Path to the endpoints.yml file")
     ] = "etc/endpoints.yml",

--- a/test/unit/test_manage.py
+++ b/test/unit/test_manage.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch, ANY, call
 
 import copy
 import yaml
+from pathlib import Path
 
 import typer
 from typer.testing import CliRunner
@@ -44,7 +45,7 @@ from openstack_project_manager.manage import (
 app = typer.Typer()
 app.command()(run)
 
-MOCK_QUOTA_CLASSES = yaml.safe_load("""
+MOCK_QUOTA_CLASSES = """
 ---
 default:
   compute:
@@ -77,7 +78,7 @@ flavor_test:
   parent: default
   flavors:
     - flavor_name
-""")
+"""
 
 
 class CloudTest(unittest.TestCase):
@@ -163,33 +164,59 @@ class TestConfiguration(CloudTest):
         assert not config.assign_admin_user
 
 
-class TestUtils(unittest.TestCase):
+class TestUtilsBase(unittest.TestCase):
 
     def setUp(self):
-        self.patcher = patch("builtins.open")
-        self.mock_open = self.patcher.start()
-        self.addCleanup(self.patcher.stop)
+        super().setUp()
+        self.mock_path_1 = MagicMock()
+        self.mock_path_1.exists.return_value = True
+        self.mock_path_1.is_file.return_value = True
+        self.mock_path_1.read_text.return_value = copy.deepcopy(MOCK_QUOTA_CLASSES)
 
-        self.patcher2 = patch("yaml.load")
-        self.mock_yaml_load = self.patcher2.start()
-        self.addCleanup(self.patcher2.stop)
-        self.mock_yaml_load.return_value = copy.deepcopy(MOCK_QUOTA_CLASSES)
+        self.mock_path_2 = MagicMock()
+        self.mock_path_2.exists.return_value = True
+        self.mock_path_2.is_file.return_value = True
+        self.mock_path_2.read_text.return_value = ""
+
+        self.default_quotaclasses_path_list = [self.mock_path_1, self.mock_path_2]
+
+
+class TestUtils(TestUtilsBase):
 
     def test_get_quotaclass_0(self):
-        result = get_quotaclass("classes.yaml", "default")
-        self.mock_open.assert_called_once_with("classes.yaml", "r")
-        self.mock_yaml_load.assert_called_once()
-        assert result == MOCK_QUOTA_CLASSES["default"]
+        result = get_quotaclass(self.default_quotaclasses_path_list, "default")
+        self.mock_path_1.exists.assert_called_once()
+        self.mock_path_1.is_file.assert_called_once()
+        self.mock_path_1.read_text.assert_called_once()
+        self.mock_path_2.exists.assert_called_once()
+        self.mock_path_2.is_file.assert_called_once()
+        self.mock_path_2.read_text.assert_called_once()
+        assert result == yaml.safe_load(MOCK_QUOTA_CLASSES)["default"]
 
     def test_get_quotaclass_1(self):
-        result = get_quotaclass("classes.yaml", "notfound")
+        result = get_quotaclass(self.default_quotaclasses_path_list, "notfound")
         assert result is None
 
     def test_get_quotaclass_2(self):
-        result = get_quotaclass("classes.yaml", "unlimited")
-        assert result["compute"]["cores"] == -1
-        result["compute"]["cores"] = MOCK_QUOTA_CLASSES["default"]["compute"]["cores"]
-        assert result == MOCK_QUOTA_CLASSES["default"]
+        result = get_quotaclass(self.default_quotaclasses_path_list, "unlimited")
+        assert (
+            result["compute"]["cores"]
+            == yaml.safe_load(MOCK_QUOTA_CLASSES)["unlimited"]["compute"]["cores"]
+        )
+        result["compute"]["cores"] = yaml.safe_load(MOCK_QUOTA_CLASSES)["default"][
+            "compute"
+        ]["cores"]
+        assert result == yaml.safe_load(MOCK_QUOTA_CLASSES)["default"]
+
+    def test_get_quotaclass_3(self):
+        self.mock_path_2.read_text.return_value = (
+            "---\noverride:\n  parent: default\n  default_volume_type: override"
+        )
+
+        result = get_quotaclass(self.default_quotaclasses_path_list, "override")
+        expected = yaml.safe_load(MOCK_QUOTA_CLASSES)["default"]
+        expected.update(dict(default_volume_type="override"))
+        assert result == expected
 
     def test_check_bool_0(self):
         project = MagicMock()
@@ -214,7 +241,7 @@ class TestUtils(unittest.TestCase):
         assert not check_bool(project, "param")
 
 
-class TestBase(CloudTest):
+class TestBase(TestUtilsBase, CloudTest):
 
     def setUp(self):
         super().setUp()
@@ -223,9 +250,19 @@ class TestBase(CloudTest):
         self.mock_open = self.patcher3.start()
         self.addCleanup(self.patcher3.stop)
 
-        self.patcher4 = patch("yaml.load")
-        self.mock_yaml_load = self.patcher4.start()
+        if not hasattr(self, "select_quota_class"):
+            self.select_quota_class = "default"
+
+        self.patcher4 = patch("openstack_project_manager.manage.get_quotaclass")
+        self.mock_get_quotaclass = self.patcher4.start()
+        self.mock_get_quotaclass.return_value = copy.copy(
+            yaml.safe_load(MOCK_QUOTA_CLASSES)[self.select_quota_class]
+        )
         self.addCleanup(self.patcher4.stop)
+
+        self.patcher5 = patch("yaml.load")
+        self.mock_yaml_load = self.patcher5.start()
+        self.addCleanup(self.patcher5.stop)
         self.mock_yaml_load.return_value = {
             "default": ["A", "B"],
             "orchestration": ["B", "C"],
@@ -240,16 +277,6 @@ class TestBase(CloudTest):
         self.config = Configuration(
             False, "cloud-name", "endpoints.yml", True, "admin-domain"
         )
-
-        if not hasattr(self, "select_quota_class"):
-            self.select_quota_class = "default"
-
-        self.patcher5 = patch("openstack_project_manager.manage.get_quotaclass")
-        self.mock_get_quotaclass = self.patcher5.start()
-        self.mock_get_quotaclass.return_value = copy.copy(
-            MOCK_QUOTA_CLASSES[self.select_quota_class]
-        )
-        self.addCleanup(self.patcher5.stop)
 
 
 class TestCheckQuota(TestBase):
@@ -670,7 +697,10 @@ class TestManageDefaultVolumeType(TestBase):
         )
 
         manage_default_volume_type(
-            self.config, self.mock_project, self.mock_domain, "classes.yml"
+            self.config,
+            self.mock_project,
+            self.mock_domain,
+            self.default_quotaclasses_path_list,
         )
 
         self.config.os_cloud.block_storage.types.assert_not_called()
@@ -696,7 +726,10 @@ class TestManageDefaultVolumeType(TestBase):
         )
 
         manage_default_volume_type(
-            self.config, self.mock_project, self.mock_domain, "classes.yml"
+            self.config,
+            self.mock_project,
+            self.mock_domain,
+            self.default_quotaclasses_path_list,
         )
 
         self.config.os_cloud.block_storage.types.assert_has_calls(
@@ -726,7 +759,10 @@ class TestManageDefaultVolumeType(TestBase):
         )
 
         manage_default_volume_type(
-            self.config, self.mock_project, self.mock_domain, "classes.yml"
+            self.config,
+            self.mock_project,
+            self.mock_domain,
+            self.default_quotaclasses_path_list,
         )
 
         self.config.os_cloud.block_storage.types.assert_has_calls(
@@ -754,7 +790,10 @@ class TestManageDefaultVolumeType(TestBase):
         )
 
         manage_default_volume_type(
-            self.config, self.mock_project, self.mock_domain, "classes.yml"
+            self.config,
+            self.mock_project,
+            self.mock_domain,
+            self.default_quotaclasses_path_list,
         )
 
         self.config.os_cloud.block_storage.types.assert_has_calls(
@@ -784,7 +823,10 @@ class TestManageDefaultVolumeType(TestBase):
         )
 
         manage_default_volume_type(
-            self.config, self.mock_project, self.mock_domain, "classes.yml"
+            self.config,
+            self.mock_project,
+            self.mock_domain,
+            self.default_quotaclasses_path_list,
         )
 
         self.config.os_cloud.block_storage.types.assert_has_calls(
@@ -805,7 +847,10 @@ class TestManageDefaultVolumeType(TestBase):
         )
 
         manage_default_volume_type(
-            self.config, self.mock_project, self.mock_domain, "classes.yml"
+            self.config,
+            self.mock_project,
+            self.mock_domain,
+            self.default_quotaclasses_path_list,
         )
 
         self.config.os_cloud.block_storage.types.assert_not_called()
@@ -832,7 +877,10 @@ class TestManageDefaultVolumeType(TestBase):
         )
 
         manage_default_volume_type(
-            self.config, self.mock_project, self.mock_domain, "classes.yml"
+            self.config,
+            self.mock_project,
+            self.mock_domain,
+            self.default_quotaclasses_path_list,
         )
 
         self.config.os_cloud.block_storage.types.assert_not_called()
@@ -1926,10 +1974,18 @@ class TestCLI(CloudTest):
                 "--classes=other.yaml",
             ],
         )
+
         self.assertEqual(result.exit_code, 0, (result, result.stdout))
 
         self.mock_process_project.assert_called_once_with(
-            ANY, self.mock_project1, "other.yaml", True, True, False, False, False
+            ANY,
+            self.mock_project1,
+            [Path("other.yaml")],
+            True,
+            True,
+            False,
+            False,
+            False,
         )
 
     def test_cli_9(self):


### PR DESCRIPTION
Allow to use the `--classes` parameter multiple times and merge all
existing files into a single document, which is then loaded as YAML.
Add an additional default for a `classes.yml` in
`/opt/configuration/environments/openstack/project-manager`.
With the condition that the aforementioned path does not exist, this
preserves the current behaviour of a single default `classes.yml` in
`etc/`.

Depends-On: https://github.com/osism/openstack-project-manager/pull/280