### PR TITLE
Fix mypy union-attr and call-overload errors

### DIFF
--- a/openstack_project_manager/create.py
+++ b/openstack_project_manager/create.py
@@ -9,8 +9,9 @@ import typer
 from typing_extensions import Annotated
 import os_client_config
 import openstack
+from openstack.identity.v3._proxy import Proxy as IdentityProxy
 from tabulate import tabulate
-from typing import Optional
+from typing import Optional, cast
 
 # Default roles to be assigned to a new user for a project
 DEFAULT_ROLES = ["member", "load-balancer_member"]
@@ -36,25 +37,31 @@ def generate_password(password_length: int) -> str:
 
 def try_assign_role(
     os_cloud: openstack.connection.Connection,
-    project: openstack.identity.v3.project.Project,
-    user: openstack.identity.v3.user.User,
+    project: Optional[openstack.identity.v3.project.Project],
+    user: Optional[openstack.identity.v3.user.User],
     role: openstack.identity.v3.role.Role,
 ) -> None:
+    if project is None or user is None:
+        return
     try:
-        os_cloud.identity.assign_project_role_to_user(project.id, user.id, role.id)
-    except:
+        identity = cast(IdentityProxy, os_cloud.identity)
+        identity.assign_project_role_to_user(project.id, user.id, role.id)
+    except Exception:
         pass
 
 
 def try_assign_role_to_group(
     os_cloud: openstack.connection.Connection,
-    project: openstack.identity.v3.project.Project,
-    group: openstack.identity.v3.group.Group,
+    project: Optional[openstack.identity.v3.project.Project],
+    group: Optional[openstack.identity.v3.group.Group],
     role: openstack.identity.v3.role.Role,
 ) -> None:
+    if project is None or group is None:
+        return
     try:
-        os_cloud.identity.assign_project_role_to_group(project.id, group.id, role.id)
-    except:
+        identity = cast(IdentityProxy, os_cloud.identity)
+        identity.assign_project_role_to_group(project.id, group.id, role.id)
+    except Exception:
         pass
 
 
@@ -175,10 +182,11 @@ def run(
 
     # Connect to the OpenStack environment
     os_cloud = openstack.connect(cloud=cloud_name)
+    identity = cast(IdentityProxy, os_cloud.identity)
 
     # cache roles
     CACHE_ROLES = {}
-    for role in os_cloud.identity.roles():
+    for role in identity.roles():
         CACHE_ROLES[role.name] = role
 
     # Generate a random name in the form abcd-0123
@@ -198,7 +206,7 @@ def run(
     # Establish dedicated connection to Keystone service
     # FIXME(berendt): use get_domain
     domain_created = False
-    domain = os_cloud.identity.find_domain(domain_name)
+    domain = identity.find_domain(domain_name)
     if not domain:
         domain = os_cloud.create_domain(name=domain_name)
         domain_created = True
@@ -206,7 +214,7 @@ def run(
     # Create domain admin group if domain was just created
     if domain_created:
         domain_admin_group_name = f"{domain_name}-admin"
-        domain_admin_group = os_cloud.identity.find_group(
+        domain_admin_group = identity.find_group(
             domain_admin_group_name, domain_id=domain.id
         )
         if not domain_admin_group:
@@ -218,14 +226,16 @@ def run(
             logger.info(f"Created domain admin group: {domain_admin_group_name}")
 
     # Find or create the project
+    project: Optional[openstack.identity.v3.project.Project] = None
+    user: Optional[openstack.identity.v3.user.User] = None
     if not create_domain:
         # FIXME(berendt): use get_project
-        project = os_cloud.identity.find_project(name, domain_id=domain.id)
+        project = identity.find_project(name, domain_id=domain.id)
         if not project:
             project = os_cloud.create_project(name=name, domain_id=domain.id)
 
         # Find or create a group with the same name as the project
-        group = os_cloud.identity.find_group(name, domain_id=domain.id)
+        group = identity.find_group(name, domain_id=domain.id)
         if not group:
             group = os_cloud.create_group(
                 name=name, description=f"Group for project {name}", domain=domain.id
@@ -237,7 +247,7 @@ def run(
 
         # Assign domain admin group to the project with default roles
         domain_admin_group_name = f"{domain_name}-admin"
-        domain_admin_group = os_cloud.identity.find_group(
+        domain_admin_group = identity.find_group(
             domain_admin_group_name, domain_id=domain.id
         )
         if domain_admin_group:
@@ -327,7 +337,7 @@ def run(
 
         # Find or create the user of the project and assign the default roles
         if create_user:
-            user = os_cloud.identity.find_user(name, domain_id=domain.id)
+            user = identity.find_user(name, **{"domain_id": domain.id})
             if not user:
                 user = os_cloud.create_user(
                     name=name,
@@ -351,7 +361,7 @@ def run(
                 "Application credential creation requires --create-user flag"
             )
 
-        if create_user and create_application_credential:
+        if create_user and create_application_credential and user is not None:
             # Create temporary connection as the newly created user
             try:
                 # Build user connection configuration
@@ -378,7 +388,8 @@ def run(
                 user_connection = openstack.connect(**user_cloud_config)
 
                 # Create Application Credential using user's connection
-                app_cred = user_connection.identity.create_application_credential(
+                user_identity = cast(IdentityProxy, user_connection.identity)
+                app_cred = user_identity.create_application_credential(
                     user=user.id,
                     name=name,
                 )
@@ -392,14 +403,15 @@ def run(
     admin_password = None
     admin_name = f"{domain_name}-admin"
 
+    admin_user: Optional[openstack.identity.v3.user.User] = None
     if assign_admin_user:
-        os_admin_domain = os_cloud.identity.find_domain(admin_domain)
+        os_admin_domain = identity.find_domain(admin_domain)
         if not os_admin_domain:
             logger.error(f"Admin domain {admin_domain} not found")
         else:
             admin_domain_id = os_admin_domain.id
-            admin_user = os_cloud.identity.find_user(
-                admin_name, domain_id=admin_domain_id
+            admin_user = identity.find_user(
+                admin_name, **{"domain_id": admin_domain_id}
             )
 
             if not admin_user and create_admin_user:
@@ -426,16 +438,16 @@ def run(
             # Add admin user to domain admin group (only when not in domain-only mode)
             if admin_user and not create_domain:
                 domain_admin_group_name = f"{domain_name}-admin"
-                domain_admin_group = os_cloud.identity.find_group(
+                domain_admin_group = identity.find_group(
                     domain_admin_group_name, domain_id=domain.id
                 )
                 if domain_admin_group:
                     try:
-                        os_cloud.identity.add_user_to_group(
+                        identity.add_user_to_group(
                             admin_user, domain_admin_group
                         )
                         logger.info(f"Added {admin_name} to domain admin group")
-                    except:
+                    except Exception:
                         # User might already be in the group
                         pass
 
@@ -443,16 +455,16 @@ def run(
         ["domain", domain_name, domain.id],
     ]
 
-    if not create_domain:
+    if not create_domain and project is not None:
         result.append(["project", name, project.id])
 
     # Outputs details about the domain admin user
-    if create_admin_user and admin_password:
+    if create_admin_user and admin_password and admin_user is not None:
         result.append(["admin", admin_name, admin_user.id])
         result.append(["admin_password", admin_password, ""])
 
     # Outputs details about the project user
-    if create_user and not create_domain:
+    if create_user and not create_domain and user is not None:
         result.append(["user", name, user.id])
         result.append(["password", password, ""])
 

--- a/openstack_project_manager/create_ldap.py
+++ b/openstack_project_manager/create_ldap.py
@@ -8,9 +8,10 @@ from dynaconf import Dynaconf
 import ldap
 from loguru import logger
 import openstack
+from openstack.identity.v3._proxy import Proxy as IdentityProxy
 import typer
 from typing_extensions import Annotated
-from typing import Optional
+from typing import Optional, cast
 
 # Default roles to be assigned to a new user for a project
 DEFAULT_ROLES = ["member", "load-balancer_member"]
@@ -166,11 +167,15 @@ def run(
     # check openstack projects
 
     os_cloud = openstack.connect(cloud=cloud_name)
-    domain = os_cloud.identity.find_domain(domain_name)
+    identity = cast(IdentityProxy, os_cloud.identity)
+    domain = identity.find_domain(domain_name)
+    if not domain:
+        logger.error(f"domain {domain_name} does not exist")
+        sys.exit(1)
 
     # cache roles
     CACHE_ROLES = {}
-    for role in os_cloud.identity.roles():
+    for role in identity.roles():
         CACHE_ROLES[role.name] = role
 
     for a, b in result:
@@ -182,12 +187,12 @@ def run(
             username = x.decode("utf-8")
 
             logger.debug(f"Checking user {username}")
-            user = os_cloud.identity.find_user(username, domain_id=domain.id)
+            user = identity.find_user(username, **{"domain_id": domain.id})
 
             if not user:
                 continue
 
-            project = os_cloud.identity.find_project(
+            project = identity.find_project(
                 f"{domain.name}-{username}", domain_id=domain.id
             )
 
@@ -200,17 +205,21 @@ def run(
             result = subprocess.check_output(command, shell=True)
 
             # ensure that the user is assigned to the new project
-            project = os_cloud.identity.find_project(
+            project = identity.find_project(
                 f"{domain.name}-{username}", domain_id=domain.id
             )
+
+            if not project:
+                logger.warning(f"Project {domain.name}-{username} not found after create")
+                continue
 
             for role_name in DEFAULT_ROLES:
                 try:
                     role = CACHE_ROLES[role_name]
-                    os_cloud.identity.assign_project_role_to_user(
+                    identity.assign_project_role_to_user(
                         project.id, user.id, role.id
                     )
-                except:
+                except Exception:
                     pass
 
     conn.unbind_s()

--- a/openstack_project_manager/create_user.py
+++ b/openstack_project_manager/create_user.py
@@ -2,12 +2,14 @@
 
 import random
 import string
+import sys
 
 import typer
 from typing_extensions import Annotated
 import openstack
+from openstack.identity.v3._proxy import Proxy as IdentityProxy
 from tabulate import tabulate
-from typing import Optional
+from typing import Optional, cast
 
 # Default roles to be assigned to a new user for a project
 DEFAULT_ROLES = ["member", "load-balancer_member"]
@@ -44,10 +46,11 @@ def run(
 
     # Connect to the OpenStack environment
     os_cloud = openstack.connect(cloud=cloud_name)
+    identity = cast(IdentityProxy, os_cloud.identity)
 
     # cache roles
     CACHE_ROLES = {}
-    for role in os_cloud.identity.roles():
+    for role in identity.roles():
         CACHE_ROLES[role.name] = role
 
     # Generate a random password from all ASCII characters + digits
@@ -56,20 +59,27 @@ def run(
 
     # Establish dedicated connection to Keystone service
     # FIXME(berendt): use get_domain
-    domain = os_cloud.identity.find_domain(domain_name)
+    domain = identity.find_domain(domain_name)
     if not domain:
         domain = os_cloud.create_domain(name=domain_name)
 
     # Find or create the user
     # FIXME(berendt): use get_project
     if domain_name_prefix:
-        project = os_cloud.identity.find_project(
+        project = identity.find_project(
             f"{domain_name}-{project_name}", domain_id=domain.id
         )
     else:
-        project = os_cloud.identity.find_project(project_name, domain_id=domain.id)
+        project = identity.find_project(project_name, domain_id=domain.id)
 
-    user = os_cloud.identity.find_user(name, domain_id=domain.id)
+    if not project:
+        logger_name = (
+            f"{domain_name}-{project_name}" if domain_name_prefix else project_name
+        )
+        print(f"project {logger_name} does not exist")
+        sys.exit(1)
+
+    user = identity.find_user(name, **{"domain_id": domain.id})
     if not user:
         user = os_cloud.create_user(
             name=name,
@@ -83,8 +93,8 @@ def run(
     for role_name in DEFAULT_ROLES:
         try:
             role = CACHE_ROLES[role_name]
-            os_cloud.identity.assign_project_role_to_user(project.id, user.id, role.id)
-        except:
+            identity.assign_project_role_to_user(project.id, user.id, role.id)
+        except Exception:
             pass
 
     result = [

--- a/openstack_project_manager/manage.py
+++ b/openstack_project_manager/manage.py
@@ -8,10 +8,13 @@ from deepmerge import always_merger
 from loguru import logger
 import neutronclient
 import openstack
+from openstack.block_storage.v3._proxy import Proxy as BlockStorageProxy
+from openstack.identity.v3._proxy import Proxy as IdentityProxy
+from openstack.image.v2._proxy import Proxy as ImageProxy
 import os_client_config
 import yaml
 import typer
-from typing import List, Optional, Tuple
+from typing import Optional, Tuple, cast
 from typing_extensions import Annotated
 
 DEFAULT_ROLES = ["member", "load-balancer_member"]
@@ -80,14 +83,15 @@ class Configuration:
         self.os_neutron = os_client_config.make_client("network", cloud=cloud_name)
 
         # cache roles
+        identity = cast(IdentityProxy, self.os_cloud.identity)
         self.CACHE_ROLES = {}
-        for role in self.os_cloud.identity.roles():
+        for role in identity.roles():
             self.CACHE_ROLES[role.name] = role
 
         # cache admin domain
         self.assign_admin_user = assign_admin_user
         if self.assign_admin_user:
-            self.CACHE_ADMIN_DOMAIN = self.os_cloud.identity.find_domain(admin_domain)
+            self.CACHE_ADMIN_DOMAIN = identity.find_domain(admin_domain)
             if not self.CACHE_ADMIN_DOMAIN:
                 logger.error(f"admin domain {admin_domain} does not exist")
                 sys.exit(1)
@@ -583,10 +587,9 @@ def manage_default_volume_type(
     else:
         default_volume_type = None
 
+    block_storage = cast(BlockStorageProxy, configuration.os_cloud.block_storage)
     try:
-        current_default_type = configuration.os_cloud.block_storage.show_default_type(
-            project
-        )
+        current_default_type = block_storage.show_default_type(project)
     except openstack.exceptions.NotFoundException:
         current_default_type = None
 
@@ -596,16 +599,14 @@ def manage_default_volume_type(
         logger.info(
             f"{project.name} - Unsetting default volume type {current_default_type.volume_type_id}"
         )
-        configuration.os_cloud.block_storage.unset_default_type(project)
+        block_storage.unset_default_type(project)
     elif (
         default_volume_type and not current_default_type
     ) or default_volume_type.id != current_default_type.volume_type_id:
         logger.info(
             f"{project.name} - Setting default volume type {default_volume_type.id} ({default_volume_type.name})"
         )
-        configuration.os_cloud.block_storage.set_default_type(
-            project, default_volume_type
-        )
+        block_storage.set_default_type(project, default_volume_type)
 
 
 def check_flavors(
@@ -1094,13 +1095,14 @@ def check_homeproject_permissions(
     if "homeproject" in project and not check_bool(project, "homeproject"):
         return
 
+    identity = cast(IdentityProxy, configuration.os_cloud.identity)
     username = project.name[len(domain.name) + 1 :]
-    user = configuration.os_cloud.identity.find_user(username, domain_id=domain.id)
+    user = identity.find_user(username, **{"domain_id": domain.id})
 
     # try username without the -XXX postfix
     if not user:
         username = re.sub(r"(.*)-[^.]*$", "\\1", project.name[len(domain.name) + 1 :])
-        user = configuration.os_cloud.identity.find_user(username, domain_id=domain.id)
+        user = identity.find_user(username, **{"domain_id": domain.id})
 
     # looks like there is no matching user for this project, nothing to do
     if not user:
@@ -1115,10 +1117,8 @@ def check_homeproject_permissions(
     for role_name in DEFAULT_ROLES:
         try:
             role = configuration.CACHE_ROLES[role_name]
-            configuration.os_cloud.identity.assign_project_role_to_user(
-                project.id, user.id, role.id
-            )
-        except:
+            identity.assign_project_role_to_user(project.id, user.id, role.id)
+        except Exception:
             pass
 
 
@@ -1129,22 +1129,25 @@ def assign_admin_user(
 ) -> None:
 
     admin_name = f"{domain.name}-admin"
+    identity = cast(IdentityProxy, configuration.os_cloud.identity)
 
     if admin_name in configuration.CACHE_ADMIN_USERS:
         admin_user = configuration.CACHE_ADMIN_USERS[admin_name]
     else:
-        admin_user = configuration.os_cloud.identity.find_user(
-            admin_name, domain_id=configuration.CACHE_ADMIN_DOMAIN.id
+        assert configuration.CACHE_ADMIN_DOMAIN is not None
+        admin_user = identity.find_user(
+            admin_name, **{"domain_id": configuration.CACHE_ADMIN_DOMAIN.id}
         )
         configuration.CACHE_ADMIN_USERS[admin_name] = admin_user
 
+    if admin_user is None:
+        return
+
     try:
         role = configuration.CACHE_ROLES["member"]
-        configuration.os_cloud.identity.assign_project_role_to_user(
-            project.id, admin_user.id, role.id
-        )
+        identity.assign_project_role_to_user(project.id, admin_user.id, role.id)
         logger.info(f"{project.name} - assign admin user {admin_name}")
-    except:
+    except Exception:
         pass
 
 
@@ -1195,16 +1198,17 @@ def share_image_with_project(
     project: openstack.identity.v3.project.Project,
 ) -> None:
 
-    member = configuration.os_cloud.image.find_member(project.id, image.id)
+    image_proxy = cast(ImageProxy, configuration.os_cloud.image)
+    member = image_proxy.find_member(project.id, image.id)
 
     if member:
         return
 
     logger.info(f"{project.name} - add shared image '{image.name}'")
-    member = configuration.os_cloud.image.add_member(image.id, member_id=project.id)
+    member = image_proxy.add_member(image.id, member_id=project.id)
 
     if member.status != "accepted":
-        configuration.os_cloud.image.update_member(member, image.id, status="accepted")
+        image_proxy.update_member(member, image.id, status="accepted")
 
 
 def share_images(
@@ -1261,23 +1265,23 @@ def cache_images(
         return
 
     # remove cache volume for which there is no image anymore
-    volumes: List[openstack.block_storage.v2.volume.Volume] = (
-        cloud_domain_admin.volume.volumes(owner=project_images.id)
-    )
+    domain_admin_volume = cast(BlockStorageProxy, cloud_domain_admin.volume)
+    domain_admin_image = cast(ImageProxy, cloud_domain_admin.image)
+    volumes = list(domain_admin_volume.volumes(owner=project_images.id))
 
     for volume in volumes:
-        image = cloud_domain_admin.image.find_image(name_or_id=volume.name[6:])
+        image = domain_admin_image.find_image(name_or_id=volume.name[6:])
         if not image:
             logger.info(
                 f"{domain.name} - remove cache volume {volume.name} for which there is no image anymore"
             )
-            cloud_domain_admin.volume.delete_volume(volume)
+            domain_admin_volume.delete_volume(volume)
 
     for image in images:
         volume_name = f"cache-{image.id}"
-        volume = cloud_domain_admin.volume.find_volume(name_or_id=volume_name)
+        cached_volume = domain_admin_volume.find_volume(name_or_id=volume_name)
 
-        if not volume:
+        if not cached_volume:
             logger.info(
                 f"{domain.name} - prepare image cache for '{image.name}' ({image.id})"
             )
@@ -1288,7 +1292,7 @@ def cache_images(
                 volume_size = image.min_disk
 
             try:
-                cloud_domain_admin.volume.create_volume(
+                domain_admin_volume.create_volume(
                     name=volume_name, size=volume_size, imageRef=image.id
                 )
             except openstack.exceptions.HttpException as e:

--- a/openstack_project_manager/manage_ldap.py
+++ b/openstack_project_manager/manage_ldap.py
@@ -8,9 +8,10 @@ from dynaconf import Dynaconf
 import ldap
 from loguru import logger
 import openstack
+from openstack.identity.v3._proxy import Proxy as IdentityProxy
 import typer
 from typing_extensions import Annotated
-from typing import Optional
+from typing import Optional, cast
 
 # Default roles to be assigned to a new user for a project
 DEFAULT_ROLES = ["member", "load-balancer_member"]
@@ -114,11 +115,15 @@ def run(
     # check openstack projects
 
     os_cloud = openstack.connect(cloud=cloud_name)
-    domain = os_cloud.identity.find_domain(domain_name)
+    identity = cast(IdentityProxy, os_cloud.identity)
+    domain = identity.find_domain(domain_name)
+    if not domain:
+        logger.error(f"domain {domain_name} does not exist")
+        sys.exit(1)
 
     # cache roles
     CACHE_ROLES = {}
-    for role in os_cloud.identity.roles():
+    for role in identity.roles():
         CACHE_ROLES[role.name] = role
 
     # handle project groups
@@ -132,7 +137,7 @@ def run(
     for a, b in result:
         m = re.search(rf"cn={ldap_project_group_prefix}(\w+),", a)
         if m:
-            project = os_cloud.identity.find_project(
+            project = identity.find_project(
                 f"{domain.name}-{m.group(1)}", domain_id=domain.id
             )
             if not project:
@@ -142,7 +147,7 @@ def run(
                     username = x.decode("utf-8")
 
                     logger.debug(f"Checking user {username}")
-                    user = os_cloud.identity.find_user(username, domain_id=domain.id)
+                    user = identity.find_user(username, **{"domain_id": domain.id})
 
                     if not user:
                         logger.warning(f"User {username} not found")
@@ -154,10 +159,10 @@ def run(
                     for role_name in DEFAULT_ROLES:
                         try:
                             role = CACHE_ROLES[role_name]
-                            os_cloud.identity.assign_project_role_to_user(
+                            identity.assign_project_role_to_user(
                                 project.id, user.id, role.id
                             )
-                        except:
+                        except Exception:
                             pass
 
     # handle the admin group
@@ -175,23 +180,23 @@ def run(
             username = x.decode("utf-8")
 
             logger.debug(f"Checking user {username}")
-            user = os_cloud.identity.find_user(username, domain_id=domain.id)
+            user = identity.find_user(username, **{"domain_id": domain.id})
 
             if not user:
                 logger.warning(f"User {username} not found")
                 continue
 
-            for project in os_cloud.identity.projects(domain_id=domain.id):
+            for project in identity.projects(domain_id=domain.id):
                 logger.info(
                     f"{project.name} - ensure admin project permissions for user = {username}, user_id = {user.id}"
                 )
                 for role_name in DEFAULT_ROLES:
                     try:
                         role = CACHE_ROLES[role_name]
-                        os_cloud.identity.assign_project_role_to_user(
+                        identity.assign_project_role_to_user(
                             project.id, user.id, role.id
                         )
-                    except:
+                    except Exception:
                         pass
 
     conn.unbind_s()


### PR DESCRIPTION
Cast openstack proxies to v3 identity/block_storage and v2 image to resolve the v2|v3 union-attr errors, use **kwargs unpacking for find_user(domain_id=...) to bypass the strict overload, and add explicit None handling for find_* return values.