### PR TITLE
Remove "parent" key from quotaclass after merge

### DIFF
--- a/openstack_project_manager/manage.py
+++ b/openstack_project_manager/manage.py
@@ -105,8 +105,15 @@ def get_quotaclass(classes: str, quotaclass: str) -> Optional[dict]:
 
     result = quotaclasses[quotaclass]
 
-    if "parent" in result and result["parent"] in quotaclasses:
-        return always_merger.merge(quotaclasses[result["parent"]], result)
+    if "parent" in result:
+        if result["parent"] in quotaclasses:
+            result = always_merger.merge(quotaclasses[result["parent"]], result)
+        else:
+            logger.error(
+                f"Could not find parent {result['parent']} for quota class {quotaclass}"
+            )
+
+        result.pop("parent", None)
 
     return result
 

--- a/test/unit/test_manage.py
+++ b/test/unit/test_manage.py
@@ -173,7 +173,7 @@ class TestUtils(unittest.TestCase):
         self.patcher2 = patch("yaml.load")
         self.mock_yaml_load = self.patcher2.start()
         self.addCleanup(self.patcher2.stop)
-        self.mock_yaml_load.return_value = MOCK_QUOTA_CLASSES
+        self.mock_yaml_load.return_value = copy.deepcopy(MOCK_QUOTA_CLASSES)
 
     def test_get_quotaclass_0(self):
         result = get_quotaclass("classes.yaml", "default")


### PR DESCRIPTION
Pop the `parent` key from the quotaclass after merge. The existing unit test `TestUtils.test_get_quotaclass_2` did not catch this. The reason is probably passing by reference, so that the `parent` key ends up in `MOCK_QUOTA_CLASSES["default"]`, thus making the final assertion pass. The modified unit test will correctly fail the previous code.